### PR TITLE
Implement skipping

### DIFF
--- a/mod/screen.rpy
+++ b/mod/screen.rpy
@@ -143,8 +143,11 @@ init 100 python in _fom_saysomething:
     # Need this limitation because else we'll quickly run out of memory.
     MAX_SESSION_SIZE = 100
 
-    # How many session entries is required in order to allow skipping.
-    SKIPPABLE_SIZE = int(MAX_SESSION_SIZE * 0.1)
+    # How many session entries is required in order to allow skipping speech.
+    SPEECH_SKIPPABLE_SIZE = int(MAX_SESSION_SIZE * 0.1)
+
+    # How many pose entries is required in order to allow skipping.
+    POSING_SKIPPABLE_SIZE = int(MAX_SESSION_SIZE * 0.03)
 
 
     class Picker(object):
@@ -547,8 +550,11 @@ init 100 python in _fom_saysomething:
             self.session_cursor += 1
             self._reset_state()
 
-            if store.say and len(self.session) >= SKIPPABLE_SIZE and not self.skip_notification_seen:
-                renpy.notify(_("At that point, Skip button will be unlocked."))
+            if len(self.session) >= (SPEECH_SKIPPABLE_SIZE if store.say else POSING_SKIPPABLE_SIZE) and not self.skip_notification_seen:
+                if store.say:
+                    renpy.notify(_("At that point, you'll be able to skip her speech."))
+                else:
+                    renpy.notify(_("At that point, you'll be able to skip posing."))
                 self.skip_notification_seen = True
 
             return RETURN_RENDER
@@ -908,7 +914,9 @@ screen fom_saysomething_picker(say=True):
                                                       .format(_("sentences") if say else _("poses"), _("Say") if say else _("Pose"),
                                                               _fom_saysomething.MAX_SESSION_SIZE,
                                                               _("Skip button on quick menu will be unlocked if your speech has more than {0} phrases.\n\n")
-                                                              .format(_fom_saysomething.SKIPPABLE_SIZE) if say else ""),
+                                                              .format(_fom_saysomething.SPEECH_SKIPPABLE_SIZE) if say else
+                                                              _("Skipping posing will be unlocked if you added more than {0} poses.\n\n")
+                                                              .format(_fom_saysomething.POSING_SKIPPABLE_SIZE)),
                                             ok_button=_("OK"),
                                             ok_action=Function(picker.enable_session_mode))
 

--- a/mod/settings.rpy
+++ b/mod/settings.rpy
@@ -42,17 +42,17 @@ screen fom_saysomething_settings:
                 hovered SetField(tooltip, "value", _("Allow Monika to blink or wink when posing."))
                 unhovered SetField(tooltip, "value", tooltip.default)
 
+            textbutton _("Enable speech/session mode by default"):
+                selected persistent._fom_saysomething_speech_mode_default
+                action ToggleField(persistent, "_fom_saysomething_speech_mode_default")
+                hovered SetField(tooltip, "value", _("Always enable speech/session mode without asking."))
+                unhovered SetField(tooltip, "value", tooltip.default)
+
         grid 2 2:
             textbutton _("Enable Markdown"):
                 selected persistent._fom_saysomething_markdown_enabled
                 action ToggleField(persistent, "_fom_saysomething_markdown_enabled")
                 hovered SetField(tooltip, "value", _("Enable Markdown text formatting when asking Monika to say something."))
-                unhovered SetField(tooltip, "value", tooltip.default)
-
-            textbutton _("Enable speech/session mode by default"):
-                selected persistent._fom_saysomething_speech_mode_default
-                action ToggleField(persistent, "_fom_saysomething_speech_mode_default")
-                hovered SetField(tooltip, "value", _("Always enable speech/session mode without asking."))
                 unhovered SetField(tooltip, "value", tooltip.default)
 
         hbox:

--- a/mod/settings.rpy
+++ b/mod/settings.rpy
@@ -10,6 +10,7 @@ define persistent._fom_saysomething_seen_screenshot_hint = False
 define persistent._fom_saysomething_speech_mode_default = False
 define persistent._fom_saysomething_pose_pause = 5.0
 define persistent._fom_saysomething_markdown_enabled = True
+define persistent._fom_saysomething_seen_skip_hint = False
 
 screen fom_saysomething_settings:
     $ tooltip = renpy.get_screen("submods", "screens").scope["tooltip"]
@@ -41,23 +42,18 @@ screen fom_saysomething_settings:
                 hovered SetField(tooltip, "value", _("Allow Monika to blink or wink when posing."))
                 unhovered SetField(tooltip, "value", tooltip.default)
 
+        grid 2 2:
             textbutton _("Enable Markdown"):
                 selected persistent._fom_saysomething_markdown_enabled
                 action ToggleField(persistent, "_fom_saysomething_markdown_enabled")
                 hovered SetField(tooltip, "value", _("Enable Markdown text formatting when asking Monika to say something."))
                 unhovered SetField(tooltip, "value", tooltip.default)
 
-        textbutton _("Show screenshot key hint"):
-            selected not persistent._fom_saysomething_seen_screenshot_hint
-            action ToggleField(persistent, "_fom_saysomething_seen_screenshot_hint")
-            hovered SetField(tooltip, "value", _("Show a hint with screenshot key when saying or posing."))
-            unhovered SetField(tooltip, "value", tooltip.default)
-
-        textbutton _("Enable speech/session mode by default"):
-            selected persistent._fom_saysomething_speech_mode_default
-            action ToggleField(persistent, "_fom_saysomething_speech_mode_default")
-            hovered SetField(tooltip, "value", _("Always enable speech/session mode without asking."))
-            unhovered SetField(tooltip, "value", tooltip.default)
+            textbutton _("Enable speech/session mode by default"):
+                selected persistent._fom_saysomething_speech_mode_default
+                action ToggleField(persistent, "_fom_saysomething_speech_mode_default")
+                hovered SetField(tooltip, "value", _("Always enable speech/session mode without asking."))
+                unhovered SetField(tooltip, "value", tooltip.default)
 
         hbox:
             xfill True

--- a/mod/topic.rpy
+++ b/mod/topic.rpy
@@ -173,6 +173,13 @@ label fom_saysomething_event_retry:
             # Memorize 5-poses for transitions.
             $ pose_5 = False
 
+            # Allow skipping here if dialogue is long enough.
+            $ _fom_enable_skipping = len(picker_session) >= _fom_saysomething.SKIPPABLE_SIZE
+            if _fom_enable_skipping:
+                $ _fom_skip_pstate = (config.allow_skipping, preferences.skip_unseen)
+                $ config.allow_skipping = True
+                $ preferences.skip_unseen = True
+
             # Ren'Py has no 'for' statement, so use 'while'.
             $ state_i = 0
             while state_i < len(picker_session):
@@ -217,6 +224,12 @@ label fom_saysomething_event_retry:
 
             # Unlock winking/blinking.
             $ set_eyes_lock(exp, False)
+
+            # Undo skipping unlock.
+            if _fom_enable_skipping:
+                $ config.allow_skipping = _fom_skip_pstate[0]
+                $ preferences.skip_unseen = _fom_skip_pstate[1]
+                $ del _fom_enable_skipping, _fom_skip_pstate
 
             # Anyway, recover buttons after we're done showing.
             if persistent._fom_saysomething_hide_quick_buttons:

--- a/mod/topic.rpy
+++ b/mod/topic.rpy
@@ -164,7 +164,7 @@ label fom_saysomething_event_retry:
 
             # Show screenshot hint.
             if not persistent._fom_saysomething_seen_screenshot_hint:
-                $ scr_key = _fom_saysomething.get_screenshot_key()
+                $ scr_key = _fom_saysomething.get_friendly_key("screenshot")
                 if scr_key is not None:
                     $ persistent._fom_saysomething_seen_screenshot_hint = True
                     $ renpy.notify(_("You can take a screenshot by pressing {0}.").format(scr_key))
@@ -174,17 +174,28 @@ label fom_saysomething_event_retry:
             $ pose_5 = False
 
             # Allow skipping here if dialogue is long enough.
-            $ _fom_enable_skipping = len(picker_session) >= _fom_saysomething.SKIPPABLE_SIZE
+            $ _fom_enable_skipping = len(picker_session) >= (_fom_saysomething.SPEECH_SKIPPABLE_SIZE if say else _fom_saysomething.POSING_SKIPPABLE_SIZE)
             if _fom_enable_skipping:
-                $ _fom_skip_pstate = (config.allow_skipping, preferences.skip_unseen)
-                $ config.allow_skipping = True
-                $ preferences.skip_unseen = True
+                if say:
+                    $ _fom_skip_pstate = (config.allow_skipping, preferences.skip_unseen)
+                    $ config.allow_skipping = True
+                    $ preferences.skip_unseen = True
+                else:
+                    # Create keybind for quick skipping posing, which can be LONG.
+                    call fom_saysomething_create_skip_keybind("_fom_saysomething_post_loop")
 
             # Ren'Py has no 'for' statement, so use 'while'.
             $ state_i = 0
             while state_i < len(picker_session):
                 $ picker._load_state(picker_session[state_i])
                 $ state_i += 1
+
+                # Give a hint about skipping; it must not be shown the same time as screenshot hint.
+                if (state_i > 1 or persistent._fom_saysomething_seen_screenshot_hint) and _fom_enable_skipping and not say:
+                    if not persistent._fom_saysomething_seen_skip_hint:
+                        $ skip_key = _fom_saysomething.get_friendly_key("_fom_skip")
+                        $ renpy.notify(_("You can stop the posing session by pressing {0}.").format(skip_key))
+                        $ persistent._fom_saysomething_seen_skip_hint = True
 
                 # Get current expression after it was changed.
                 $ exp = picker.get_sprite_code()
@@ -216,44 +227,48 @@ label fom_saysomething_event_retry:
                     pause picker.pose_delay
                     window show
 
-            # Cleanup.
-            $ del state_i, picker_session
+            label _fom_saysomething_post_loop:
+                # Cleanup.
+                $ del state_i, picker_session
 
-            # No longer posing.
-            $ _fom_saysomething.posing = False
+                # No longer posing.
+                $ _fom_saysomething.posing = False
 
-            # Unlock winking/blinking.
-            $ set_eyes_lock(exp, False)
+                # Unlock winking/blinking.
+                $ set_eyes_lock(exp, False)
 
-            # Undo skipping unlock.
-            if _fom_enable_skipping:
-                $ config.allow_skipping = _fom_skip_pstate[0]
-                $ preferences.skip_unseen = _fom_skip_pstate[1]
-                $ del _fom_enable_skipping, _fom_skip_pstate
+                # Undo skipping unlock.
+                if _fom_enable_skipping:
+                    if say:
+                        $ config.allow_skipping = _fom_skip_pstate[0]
+                        $ preferences.skip_unseen = _fom_skip_pstate[1]
+                        $ del _fom_enable_skipping, _fom_skip_pstate
+                    else:
+                        call fom_saysomething_remove_skip_keybind
 
-            # Anyway, recover buttons after we're done showing.
-            if persistent._fom_saysomething_hide_quick_buttons:
-                call fom_saysomething_event_buttons(_show=True)
+                # Anyway, recover buttons after we're done showing.
+                if persistent._fom_saysomething_hide_quick_buttons:
+                    call fom_saysomething_event_buttons(_show=True)
 
-            show monika 3tua at t11
-            m 3tua "Well? {w=0.3}Did I do it good enough?"
-            m 1hub "Hope you liked it, ahaha~"
+                show monika 3tua at t11
+                m 3tua "Well? {w=0.3}Did I do it good enough?"
+                m 1hub "Hope you liked it, ahaha~"
 
-            if say:
-                $ quip = _("say something else")
-            else:
-                $ quip = _("pose for you again")
+                if say:
+                    $ quip = _("say something else")
+                else:
+                    $ quip = _("pose for you again")
 
-            m 3eub "Do you want me to [quip]?{nw}"
-            $ _history_list.pop()
-            menu:
-                m "Do you want me to [quip]?{fast}"
+                m 3eub "Do you want me to [quip]?{nw}"
+                $ _history_list.pop()
+                menu:
+                    m "Do you want me to [quip]?{fast}"
 
-                "Yes.":
-                    jump fom_saysomething_event_retry
+                    "Yes.":
+                        jump fom_saysomething_event_retry
 
-                "No.":
-                    m 1hua "Okay~"
+                    "No.":
+                        m 1hua "Okay~"
 
     # Once done with all the speech/posing, remove the images saved in cache
     # that weren't cached before (so that we don't touch MAS sprites.)
@@ -271,4 +286,22 @@ label fom_saysomething_event_buttons(_show=True):
         $ HKBShowButtons()
     else:
         $ HKBHideButtons()
+    return
+
+init python:
+    def _fom_skip_to_label(_label):
+        def skip():
+            renpy.jump(_label)
+        return skip
+
+label fom_saysomething_create_skip_keybind(_label):
+    $ config.keymap["_fom_skip"] = ["x", "X"]
+    $ del config.keymap["derandom_topic"]
+    $ config.underlay.append(renpy.Keymap(_fom_skip=_fom_skip_to_label(_label)))
+    return
+
+label fom_saysomething_remove_skip_keybind():
+    $ config.keymap["derandom_topic"] = ["x", "X"]
+    $ del config.keymap["_fom_skip"]
+    $ config.underlay.pop(-1)
     return

--- a/mod/util.rpy
+++ b/mod/util.rpy
@@ -91,21 +91,21 @@ init -200 python in _fom_saysomething:
             if tup in renpy.display.image.images:
                 del renpy.display.image.images[tup]
 
-    def get_screenshot_key():
+    def get_friendly_key(action):
         """
-        Retrieves user-friendly key combination for a screenshot.
-        If keymap is not configured for screenshots, returns None.
+        Retrieves user-friendly key combination for a given action.
+        If keymap is not configured for this action, returns None.
 
         OUT:
             str:
                 User-friendly key combination.
 
             None:
-                If keymap is not configured for taking screenshots.
+                If keymap is not configured.
         """
 
         # May be not set or be empty here.
-        key = renpy.config.keymap.get("screenshot")
+        key = renpy.config.keymap.get(action)
         if key is None or len(key) == 0:
             return None
 


### PR DESCRIPTION
In dialogues, skipping will be possible using Ren'Py *Skip* button on quick menu when more than 10 phrases are added.

In posing mode, skipping will be possible using `X` key when more than 3 poses are added.