### PR TITLE
Implement line copy

### DIFF
--- a/mod/generation.rpy
+++ b/mod/generation.rpy
@@ -342,6 +342,23 @@ init 101 python in _fom_saysomething:
         # underscores, and converts the entire string to lowercase.
         return re.sub("[^a-zA-Z0-9_]", "_", name).strip("_").lower()
 
+    def generate_line(poses, text):
+        """
+        Generates a dialogue line of poses, position and text.
+
+        IN:
+            poses -> dict[str, int]:
+                Pose cursor dictionary.
+            text -> str:
+                Current text input.
+
+        OUT:
+            RenPy script statement with sprite code and with Markdown rendered.
+        """
+
+        text = markdown.render(text)
+        return ('m {0} "{1}"'.format(get_sprite_code(poses), text))
+
     def generate_script(session, name):
         """
         Generates script of the provided session (see Picker in screen.rpy)
@@ -360,11 +377,6 @@ init 101 python in _fom_saysomething:
 
         def get_dialogue_lines():
             """Generates dialogue lines indented by four spaces."""
-
-            def get_dialog_line(poses, pos, text):
-                """Generates a dialogue line of poses, position and text."""
-                text = markdown.render(text)
-                return ('m {0} "{1}"'.format(get_sprite_code(poses), text))
 
             def get_trans_line(poses, pos, dissolve=False):
                 """Generates a transition line of poses, position and dissolve."""
@@ -396,7 +408,7 @@ init 101 python in _fom_saysomething:
                     leaning = poses["pose"] == 4
 
                 # Append dialog line.
-                lines.append(get_dialog_line(poses, pos, text))
+                lines.append(generate_line(poses, text))
 
             # Glue dialog lines, prepending them with indent.
             return "\n".join(map(lambda it: "    " + it, lines))

--- a/mod/screen.rpy
+++ b/mod/screen.rpy
@@ -149,7 +149,7 @@ init 100 python in _fom_saysomething:
         detailed declaration of keys and IDs.)
 
         IN:
-            post_cursors -> dict[str, int]:
+            pose_cursors -> dict[str, int]:
                 Pose cursor dictionary.
 
         OUT:
@@ -517,16 +517,23 @@ init 100 python in _fom_saysomething:
             self.changed = True
             return RETURN_RENDER
 
-        def copy_to_clipboard(self):
+        def copy_to_clipboard(self, line=False):
             """
             Retrieves sprite code from pickers state and saves it to clipboard.
+
+            IN:
+                line -> bool, default False:
+                    Whether to copy a sprite code or an entire statement.
 
             OUT:
                 RETURN_RENDER:
                     Always returns RETURN_RENDER.
             """
 
-            code = get_sprite_code(self.pose_cursors)
+            if line:
+                code = generate_line(self.pose_cursors, self.text)
+            else:
+                code = get_sprite_code(self.pose_cursors)
             pygame.scrap.put(pygame.SCRAP_TEXT, bytes(code, "utf-8"))
             return RETURN_RENDER
 
@@ -1428,7 +1435,10 @@ screen fom_saysomething_picker(say=True):
 
             textbutton _("Copy"):
                 xysize(103, None)
-                action Function(picker.copy_to_clipboard)
+                if pygame.key.get_pressed()[pygame.K_LSHIFT]:
+                    action Function(picker.copy_to_clipboard, line=True)
+                else:
+                    action Function(picker.copy_to_clipboard)
 
             textbutton _("Paste"):
                 xysize(102, None)


### PR DESCRIPTION
Now pressing SHIFT while clicking on 'Copy' will copy the entire line with Markdown rendered instead of just expression.

- [x] Tested, works
- [x] Tested, does not interfere with normal generation